### PR TITLE
SteamID Collection with python-social-auth

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1083,6 +1083,30 @@ def automail_prize_shipping_notifications(request):
     form = forms.AutomailPrizeShippingNotifyForm(prizewinners=prizewinners)
   return render(request, 'admin/automail_prize_winners_shipping_notifications.html', { 'form': form })
 
+@admin_auth('tracker.change_donor')
+def draw_steam_ids(request):
+  currentEvent = viewutil.get_selected_event(request)
+  event_id = currentEvent.id if currentEvent else None
+
+  # Form submission
+  if request.method == 'POST':
+    form = forms.DrawSteamIdForm(data=request.POST)
+    if form.is_valid():
+      steam_ids = filters.get_donor_steam_ids(form.cleaned_data['min_donation'],
+        form.cleaned_data['max_donation'], event_id)
+      print steam_ids
+      return render(request, 'admin/draw_steam_ids_post.html', { 'steamids': steam_ids,
+        'min': form.cleaned_data['min_donation'],
+        'max': form.cleaned_data['max_donation']})
+  # Form request
+  else:
+    form = forms.DrawSteamIdForm()
+  return render(request, 'admin/generic_form.html', 
+                dictionary=dict(
+                  title='Draw Steam IDs',
+                  form=form,
+                  action=request.path,
+                ))
 
 # http://stackoverflow.com/questions/2223375/multiple-modeladmins-views-for-same-model-in-django-admin
 # viewName - what to call the model in the admin
@@ -1131,6 +1155,7 @@ def get_urls():
                   url('start_run/(?P<run>\d+)', start_run_view, name='start_run'),
                   url('automail_prize_contributors', automail_prize_contributors, name='automail_prize_contributors'),
                   url('draw_prize_winners', draw_prize_winners, name='draw_prize_winners'),
+                  url('draw_steam_ids', draw_steam_ids, name='draw_steam_ids'),
                   url('automail_prize_winners', automail_prize_winners, name='automail_prize_winners'),
                   url('automail_prize_accept_notifications', automail_prize_accept_notifications, name='automail_prize_accept_notifications'),
                   url('automail_prize_shipping_notifications', automail_prize_shipping_notifications, name='automail_prize_shipping_notifications'),

--- a/filters.py
+++ b/filters.py
@@ -1,5 +1,6 @@
 from django.db.models import Count,Sum,Max,Avg,Q,F
 from tracker.models import *
+from django.contrib.auth.models import User
 from datetime import *
 import pytz
 import viewutil
@@ -424,6 +425,26 @@ def default_time(time):
 _DEFAULT_DONATION_DELTA = timedelta(hours=3)
 _DEFAULT_DONATION_MAX = 200
 _DEFAULT_DONATION_MIN = 25
+
+def get_donor_steam_ids(min_donation=None, max_donation=None, event_id=None):
+  valid_donor_caches = DonorCache.objects
+  if event_id:
+    valid_donor_caches = valid_donor_caches.filter(event_id=event_id)
+  if min_donation:
+    valid_donor_caches = valid_donor_caches.filter(donation_total__gte=min_donation)
+  if max_donation:
+    valid_donor_caches = valid_donor_caches.filter(donation_total__lte=max_donation)
+  donor_ids = valid_donor_caches.values_list('donor_id', flat=True)
+  donors_objects = Donor.objects.filter(id__in=donor_ids)
+  user_ids = donors_objects.values('user_id')
+  valid_users = User.objects.filter(id__in=user_ids)
+
+  steam_ids = list()
+  for user in valid_users:
+    steam_auth = user.social_auth.filter(provider='steam')
+    if steam_auth:
+      steam_ids.append(steam_auth.first().uid)
+  return steam_ids
 
 # There is a slight complication in how this works, in that we cannot use the 'limit' set-up as a general filter mechanism, so these methods return the actual result, rather than a filter object
 def get_recent_donations(donations=None, minDonations=_DEFAULT_DONATION_MIN, maxDonations=_DEFAULT_DONATION_MAX, delta=_DEFAULT_DONATION_DELTA, queryOffset=None):

--- a/forms.py
+++ b/forms.py
@@ -61,6 +61,7 @@ __all__ = [
     'PrizeAcceptanceForm',
     'PrizeAcceptanceWithAddressForm',
     'PrizeShippingFormSet',
+    'DrawSteamIdForm'
 ]
 
 
@@ -343,6 +344,15 @@ class EventFilterForm(forms.Form):
         super(EventFilterForm, self).__init__(*args, **kwargs)
         self.fields['event'] = forms.ModelChoiceField(queryset=models.Event.objects.all(
         ), empty_label="All Events", initial=event, required=not allow_empty)
+
+
+class DrawSteamIdForm(forms.Form):
+    min_donation = forms.DecimalField(decimal_places=2, max_digits=20,label='Minimum Qualifying Donation', validators=[positive],
+                                      help_text='Please enter the minimum donation total to qualify the donor for this draw',
+                                      required=False)
+    max_donation = forms.DecimalField(decimal_places=2, max_digits=20, label='Maximum Qualifying Donation', validators=[positive],
+                                      help_text='Please enter the maximum donation total to qualify the donor for this draw',
+                                      required=False)
 
 
 class PrizeSubmissionForm(forms.Form):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ psycopg2==2.6.1
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 python-dateutil==2.4.2
+python-social-auth==0.2.19
 pytz==2015.6
 rsa==3.2
 six==1.9.0

--- a/templates/admin/draw_steam_ids_post.html
+++ b/templates/admin/draw_steam_ids_post.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% load donation_tags %}
+{% load i18n %}
+
+
+{% block title %}Drawn SteamIDs{% endblock %}
+
+{% block head %}
+<link href="{{STATIC_URL}}css/ajax_select.css" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{{STATIC_URL}}js/ajax_select.js"></script>
+<link href="{{STATIC_URL}}adminprocessing.css" type="text/css" media="ajax" rel="stylesheet" />
+<script src="{{STATIC_URL}}adminprocessing.js"></script>
+{% endblock %}
+
+{% block nav %}
+{% endblock %}
+
+{% block content %}
+
+<p>Drew the following Steam IDs for donations
+{% if min and max %}
+between ${{ min }} and ${{ max }}:
+{% elif min %}
+above ${{ min }}:
+{% elif max %}
+below ${{ max }}:
+{% else %}
+of all donor levels:
+{% endif %}
+
+</p>
+<ul>
+
+{% for steam_id in steamids %}
+<li>{{ steam_id }}</li>
+{% endfor %}
+
+</ul>
+
+{% endblock %}

--- a/templates/admin/tracker_admin.html
+++ b/templates/admin/tracker_admin.html
@@ -16,6 +16,7 @@
         <tr><td><a href="{% url 'admin:read_donations' %}">Read Donations</a></td></tr>
         <tr><td><a href="{% url 'admin:select_event' %}">Select an Event</a></td></tr>
         <tr><td><a href="{% url 'admin:show_completed_bids' %}">Show Completed Bids</a></td></tr>
+        <tr><td><a href="{% url 'admin:draw_steam_ids' %}">Draw SteamIDs</a></td></tr>
         </tbody>
     </table>
 </div>

--- a/templates/tracker/user_index.html
+++ b/templates/tracker/user_index.html
@@ -7,6 +7,20 @@
 {% block content %}
 
 <h3>Self Service Options</h3>
+{% if steam_auth %}
+<p>Authenticated</p>
+<form action="{% url 'social:disconnect' 'steam' %}" method="POST">
+    {% csrf_token %}
+    <button type="submit">Disconnect</button>
+</form>
+<p>Known SteamID: <a href="http://steamcommunity.com/profiles/{{ steam_auth }}">{{ steam_auth }}</a></p>
+{% else %}
+<p>Unauthenticated</p>
+<form action="{% url 'social:begin' 'steam' %}" method="POST">
+    {% csrf_token %}
+    <button type="submit">Connect to steam</button>
+</form>
+{% endif %}
 
 {% if not eventList %}
   There are no events to show

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,6 +8,8 @@ import post_office.models
 import tracker.auth
 import tracker.tests.util as test_util
 
+from social.apps.django_app.default.models import UserSocialAuth
+
 AuthUser = get_user_model()
 
 TEST_AUTH_MAIL_TEMPLATE = post_office.models.EmailTemplate(content="user:{{user}}\nurl:{{reset_url}}")
@@ -38,3 +40,14 @@ class TestRegisterEmailSend(TestCase):
         newUser = AuthUser.objects.create(username='dummyuser',email='test@email.com',is_active=False)
         self.assertRaises(Exception, tracker.auth.send_password_reset_mail('', newUser, template=TEST_AUTH_MAIL_TEMPLATE))
     
+
+class TestSocialAuth(TestCase):
+
+    def test_steam_association(self):
+        newUser = AuthUser.objects.create(username='dummyuser',email='test@email.com',is_active=False)
+        socialAuth = UserSocialAuth.objects.create(user=newUser,provider='steam',uid='123456')
+        assert newUser.social_auth.filter(provider='steam').first().uid == '123456'
+
+    def test_no_social_auth(self):
+        nonSocialUser = AuthUser.objects.create(username='dummyuser',email='test@email.com',is_active=False)
+        assert nonSocialUser.social_auth.filter(provider='steam').first() == None

--- a/views/common.py
+++ b/views/common.py
@@ -33,10 +33,15 @@ def tracker_context(request, qdict=None):
     request.LANGUAGE_CODE = translation.get_language()
     profile = None
     qdict = qdict or {}
+    try:
+        steam_id = request.user.social_auth.filter(provider='steam').first().uid
+    except Exception as e:
+        steam_id = None
     qdict.update({
         'djangoversion' : dv(),
         'pythonversion' : pv(),
         'user' : request.user,
+        'steam_auth': steam_id,
         'profile' : profile,
         'next' : request.POST.get('next', request.GET.get('next', request.path)),
         'starttime' : starttime,


### PR DESCRIPTION
(Fixed and reopened version of #1)
- Logged in users can link (and unlink) their Steam account in the `user_index` page
- SteamIDs are saved by `python-social-auth` and can be manually accessed - if necessary - in the `Social Auth` panel on the admin page.
- A new admin command 'Draw SteamIDs' has been created to allow selection of donor SteamIDs based on total donations throughout the event
