### PR TITLE
Tied donor steam ID to donation

### DIFF
--- a/migrations/0037_donation_steamid.py
+++ b/migrations/0037_donation_steamid.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tracker', '0036_tech_notes_permissions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='donation',
+            name='steamid',
+            field=models.CharField(max_length=64, verbose_name=b'SteamID 64', blank=True),
+        ),
+    ]

--- a/models/donation.py
+++ b/models/donation.py
@@ -59,6 +59,7 @@ class Donation(models.Model):
   requestedalias = models.CharField(max_length=32, null=True, blank=True, verbose_name='Requested Alias')
   requestedemail = models.EmailField(max_length=128, null=True, blank=True, verbose_name='Requested Contact Email')
   commentlanguage = models.CharField(max_length=32, null=False, blank=False, default='un', choices=LanguageChoices, verbose_name='Comment Language')
+  steamid = models.CharField(max_length=64,blank=True,verbose_name='SteamID 64')
   class Meta:
     app_label = 'tracker'
     permissions = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ psycopg2==2.6.1
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
 python-dateutil==2.4.2
+python-social-auth==0.2.20
 pytz==2015.6
 rsa==3.2
 six==1.9.0

--- a/steam_social.py
+++ b/steam_social.py
@@ -1,0 +1,6 @@
+from django.shortcuts import redirect
+
+def save_uid_to_session(strategy, uid=None, **kwargs):
+  if uid:
+    strategy.session_set('uid', uid)
+  return redirect(strategy.session_get('next'))

--- a/templates/tracker/donate.html
+++ b/templates/tracker/donate.html
@@ -384,6 +384,12 @@
     <span style="color:red">
     {{ commentform.non_field_errors }}
     </span>
+    <br>
+    {% if request.session.uid %}
+      <p>Connected to steam!</p>
+    {% else %}
+      <a href="{% url 'social:begin' 'steam' %}?next={{ request.get_full_path }}">Connect to Steam.</a>
+    {% endif %}
     {% for field in commentform.visible_fields %}
         <span style="color:red">
         {{ field.errors }}

--- a/views/donateviews.py
+++ b/views/donateviews.py
@@ -63,7 +63,10 @@ def donate(request, event):
           donation.requestedalias = commentform.cleaned_data['requestedalias']
           donation.requestedemail = commentform.cleaned_data['requestedemail']
           donation.currency = event.paypalcurrency
+          if request.session.get('uid'):
+             donation.steamid = request.session.get('uid')
           donation.save()
+
           for bidform in bidsform:
             if 'bid' in bidform.cleaned_data and bidform.cleaned_data['bid']:
               bid = bidform.cleaned_data['bid']


### PR DESCRIPTION
Improved method of SteamID collection.
We're not using the donation-tracker user model, so I refactored the SteamID collection system to work with only session/cookie information.

_Note_: Needs the necessary changes applied to [donation-tracker-toplevel](https://github.com/TipoftheHats/donation-tracker-toplevel/pull/2) to function correctly.
