### PR TITLE
Disambiguate choices in MergeObjectsForm with object IDs

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -321,8 +321,8 @@ class MergeObjectsForm(forms.Form):
         self.model = model
         self.choices = []
         for objId in objects:
-            self.choices.append(
-                (objId, unicode(self.model.objects.get(id=objId))))
+            choice_name = '#%d: ' % objId + unicode(self.model.objects.get(id=objId))
+            self.choices.append((objId, choice_name))
         self.fields['root'] = forms.ChoiceField(
             choices=self.choices, required=True)
         self.fields['objects'] = forms.CharField(initial=','.join(


### PR DESCRIPTION
When merging donors with the same display name, there's no way to know
which is which without looking at form source. This change makes it
easier for any user merging objects to see which user they are picking.

Before:
![image](https://user-images.githubusercontent.com/4412803/40621104-6ded6ebc-6269-11e8-854c-4d297b717a3b.png)

After:
![image](https://user-images.githubusercontent.com/4412803/40621115-78506e90-6269-11e8-9f6b-104802b50322.png)
(1 and 2 are the object IDs)