### PR TITLE
Verify that an IPN's recipient matches the intended event recipient

### DIFF
--- a/paypalutil.py
+++ b/paypalutil.py
@@ -8,6 +8,9 @@ import random
 from decimal import *
 import pytz
 
+class SpoofedIPNException(Exception):
+    pass
+
 def create_ipn(request):
   flag = None
   ipnObj = None
@@ -32,9 +35,32 @@ def create_ipn(request):
       donation = get_ipn_donation(ipnObj)
       if not donation:
         raise Exception('No donation associated with this IPN')
-      ipnObj.verify(None, donation.event.paypalemail)
+      verify_ipn_recipient_email(ipn, donation.event.paypalemail)
+      ipnObj.verify(None)
   ipnObj.save()
   return ipnObj
+
+def verify_ipn_recipient_email(ipn, email):
+    """
+    Raises SpoofedIPNException if the recipient in the IPN doesn't match
+    the provided email.
+
+    In IPNs, business is set the same as receiver_email if the payment
+    was sent to the primary email of an account. If not, business is
+    set to the account email in the transaction and receiver_email
+    remains the primary email of an account.
+
+    That is, for a payment to an account, business may change from
+    transaction to transaction, but receiver_email stays the same as
+    long as the recipient doesn't change their primary email.
+
+    https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNandPDTVariables/#mass-pay-variables
+    """
+    recipient_email = ipn.business if ipn.business else ipn.receiver_email
+    if recipient_email.lower() != email.lower():
+        raise SpoofedIPNException(
+            "IPN receiver %s doesn't match %s".format(recipient_email, email)
+        )
 
 def get_ipn(request):
   ipnObj = PayPalIPN()


### PR DESCRIPTION
PayPal recommends that receiver_email be checked to ensure that an IPN
is not a spoof [1]. We perform this verification while creating the IPN
model when responding to a webhook hit from PayPal rather than relying
on django-paypal to verify this.

[1] https://developer.paypal.com/docs/classic/ipn/integration-guide/IPNIntro/#ipn-protocol-and-architecture