### PR TITLE
Add sort option to read_donations

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -613,6 +613,10 @@ def apply_feed_filter(query, model, feedName, params, user=None, noslice=False):
         elif feedName == 'toread':
             query = query.filter(Q(readstate='READY') &
                                  Q(transactionstate='COMPLETED'))
+                                 
+            if 'sort' in params:
+                toReadSort = 'id' if params['sort'] == 'asc' else '-id'
+                query = query.order_by(toReadSort)
     elif model in ['bid', 'bidtarget', 'allbids']:
         if feedName == 'open':
             query = query.filter(state='OPENED')

--- a/templates/admin/read_donations.html
+++ b/templates/admin/read_donations.html
@@ -70,6 +70,7 @@ thead th {
 
 var partitionLanguageElem = "#partition_language";
 var languageCookieName = 'donation_processing_language';
+var sortOptionElem = "#search_sort";
 
 var trackerAPI = new TrackerAPI("{% settings_value "SITE_PREFIX" %}");
 
@@ -155,6 +156,7 @@ function runSearch() {
 
   searchParams = {
     feed : "toread",
+    sort: $(sortOptionElem).val()
   };
 
   {% if currentEvent %}
@@ -238,6 +240,11 @@ function runSearch() {
   <option value="un">Unknown</option>
 </select>
 </label>
+<label>Sort</label>
+<select id="search_sort">
+  <option value="desc">New->Old</option>
+  <option value="asc">Old->New</option>
+</select>
 <button onclick="runSearch();">Refresh</button>
 
 <span id="id_loading"></span>


### PR DESCRIPTION
This was requested by the following Trello card: https://trello.com/c/ftalQSx7/106-on-readdonations-give-sorting-options-specifically-to-be-able-to-sort-from-oldest-to-newest-rather-than-newest-to-oldest
